### PR TITLE
Dismiss dialog message for transaction status

### DIFF
--- a/Content/1.1.2 - Transaction Status/transactionStatus.json
+++ b/Content/1.1.2 - Transaction Status/transactionStatus.json
@@ -2,5 +2,6 @@
 	"transaction_status_completing_text": "Completing Transaction…",
 	"transaction_status_success_title": "Success",
 	"transaction_status_success_text": "Your transaction was successful",
-	"transaction_status_failure_title": "Something went wrong"
+	"transaction_status_failure_title": "Something went wrong",
+	"transaction_status_dismiss_dialog_message": "Dismissing this modal will not cancel this transaction, but you will not get any more notifications regarding the transaction's status."
 }


### PR DESCRIPTION
Message that is shown when the user has sent a transaction and
1. The transaction approval screen closes
2. The pending slide-up is visible,
3. but the user clicks on `X` while we are still polling for transaction status.

![Screenshot_20230614_115116](https://github.com/radixdlt/apps-localization-src/assets/125959264/83d552fd-fdee-4ef8-b825-4ee4a37be1a0)
 
