### PR TITLE
Remove "currently" from "Currently connected"

### DIFF
--- a/Content/0.4.8 - Seed Phrases/seedPhrases.json
+++ b/Content/0.4.8 - Seed Phrases/seedPhrases.json
@@ -16,5 +16,9 @@
 	"seedPhrases_seedPhrase_headingScan": "Seed Phrase",
 	"seedPhrases_seedPhrase_noConnectedAccountsScan": "Not yet connected to any Accounts",
 	"seedPhrases_seedPhrase_oneConnectedAccountScan": "Currently connected to 1 Account",
-	"seedPhrases_seedPhrase_multipleConnectedAccountsScan": "Currently connected to %d Accounts"
+	"seedPhrases_seedPhrase_multipleConnectedAccountsScan": "Currently connected to %d Accounts",
+
+	"seedPhrases_seedPhrase_noConnectedAccounts": "Not connected to any Accounts",
+	"seedPhrases_seedPhrase_oneConnectedAccount": "Connected to 1 Account",
+	"seedPhrases_seedPhrase_multipleConnectedAccounts": "Connected to %d Accounts"
 }


### PR DESCRIPTION
Adds these (per [this ticket](https://radixdlt.atlassian.net/browse/ABW-2655)):

```
"seedPhrases_seedPhrase_noConnectedAccounts": "Not connected to any Accounts",
"seedPhrases_seedPhrase_oneConnectedAccount": "Connected to 1 Account",
"seedPhrases_seedPhrase_multipleConnectedAccounts": "Connected to %d Accounts",
```

Next PR will remove the specialised versions:


```
"seedPhrases_seedPhrase_noConnectedAccountsReveal": "Not connected to any Accounts",
"seedPhrases_seedPhrase_oneConnectedAccountReveal": "Connected to 1 Account",
"seedPhrases_seedPhrase_multipleConnectedAccountsReveal": "Connected to %d Accounts",
	
"seedPhrases_seedPhrase_noConnectedAccountsScan": "Not yet connected to any Accounts",
"seedPhrases_seedPhrase_oneConnectedAccountScan": "Currently connected to 1 Account",
"seedPhrases_seedPhrase_multipleConnectedAccountsScan": "Currently connected to %d Accounts",

```