### PR TITLE
Biometrics App Lock available alert strings

### DIFF
--- a/Content/Biometrics/biometrics.json
+++ b/Content/Biometrics/biometrics.json
@@ -11,5 +11,7 @@
 	"biometrics_deviceNotSecureAlert_title": "Unsecured Device",
 	"biometrics_deviceNotSecureAlert_message": "Your device currently has no device access security set, such as biometrics or a PIN. The Radix Wallet requires this to be set for your security.",
 	"biometrics_deviceNotSecureAlert_openSettings": "Open Settings",
-	"biometrics_deviceNotSecureAlert_quit": "Quit"
+	"biometrics_deviceNotSecureAlert_quit": "Quit",
+	"biometrics_appLockAvailableAlert_title": "Advanced Lock Disabled",
+	"biometrics_appLockAvailableAlert_message": "Your phone was updated and now supports Apple's built-in App Lock feature."
 }


### PR DESCRIPTION
Adds alert strings for the App Lock feature availability. These will be used only on iOS.